### PR TITLE
Cast to "const int" explicit instead of "const"

### DIFF
--- a/packcc.c
+++ b/packcc.c
@@ -3702,8 +3702,8 @@ static bool generate(context_t *ctx) {
                     }
                     fputs(
                         "#define _0 pcc_get_capture_string(__pcc_ctx, &__pcc_in->data.leaf.capt0)\n"
-                        "#define _0s ((const)__pcc_in->data.leaf.capt0.range.start)\n"
-                        "#define _0e ((const)__pcc_in->data.leaf.capt0.range.end)\n",
+                        "#define _0s ((const int)__pcc_in->data.leaf.capt0.range.start)\n"
+                        "#define _0e ((const int)__pcc_in->data.leaf.capt0.range.end)\n",
                         stream
                     );
                     for (k = 0; k < c->len; k++) {


### PR DESCRIPTION
__pcc_in->data.leaf.capt0.range.start and .end are casted to "const"
in generate(). Compiling the generated code with "gcc -std=gnu99 -Wall",
the compiler warns as follows:

    peg/java.c:1815:5: warning: type defaults to ‘int’ in type name [-Wimplicit-int]
	 eatComma(auxil, _0s);
	 ^~~~~~~~

This change suppresses the warning.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>