### PR TITLE
Provide the way to replace printf formatter for size_t

### DIFF
--- a/packcc.c
+++ b/packcc.c
@@ -39,6 +39,10 @@
 #endif
 #endif
 
+#ifndef SIZE_T_FMT_CHAR
+#define SIZE_T_FMT_CHAR "z"
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -2108,17 +2112,17 @@ static code_reach_t generate_matching_string_code(generate_t *gen, const char *v
             write_characters(gen->stream, ' ', indent);
             fputs("if (\n", gen->stream);
             write_characters(gen->stream, ' ', indent + 4);
-            fprintf(gen->stream, "pcc_refill_buffer(ctx, %zu) < %zu ||\n", n, n);
+            fprintf(gen->stream, "pcc_refill_buffer(ctx, %" SIZE_T_FMT_CHAR "u) < %" SIZE_T_FMT_CHAR "u ||\n", n, n);
             for (i = 0; i < n - 1; i++) {
                 write_characters(gen->stream, ' ', indent + 4);
-                fprintf(gen->stream, "((const char *)(ctx->buffer.buf + ctx->pos))[%zu] != '%s' ||\n", i, escape_character(value[i], &s));
+                fprintf(gen->stream, "((const char *)(ctx->buffer.buf + ctx->pos))[%" SIZE_T_FMT_CHAR "u] != '%s' ||\n", i, escape_character(value[i], &s));
             }
             write_characters(gen->stream, ' ', indent + 4);
-            fprintf(gen->stream, "((const char *)(ctx->buffer.buf + ctx->pos))[%zu] != '%s'\n", i, escape_character(value[i], &s));
+            fprintf(gen->stream, "((const char *)(ctx->buffer.buf + ctx->pos))[%" SIZE_T_FMT_CHAR "u] != '%s'\n", i, escape_character(value[i], &s));
             write_characters(gen->stream, ' ', indent);
             fprintf(gen->stream, ") goto L%04d;\n", onfail);
             write_characters(gen->stream, ' ', indent);
-            fprintf(gen->stream, "ctx->pos += %zu;\n", n);
+            fprintf(gen->stream, "ctx->pos += %" SIZE_T_FMT_CHAR "u;\n", n);
             if (!bare) {
                 indent -= 4;
                 write_characters(gen->stream, ' ', indent);


### PR DESCRIPTION
It seems that printf implementation of some versions of Windows doesn't
provide "%zu". As the result, packcc crashes on the platforms.

This change provides the way to define an alternative format char for
size_t from compiler command line.

If you want to use "%lu" for printing size_t values, compile packcc with
following command line:

	  $ gcc -o packcc packcc.c -DSIZE_T_FMT_CHAR=\"l\"

If you want to use "%u" for printing size_t values, compile packcc with
following command line:

	  $ gcc -o packcc packcc.c -DSIZE_T_FMT_CHAR=\"\"

Signed-off-by: Masatake YAMATO <yamato@redhat.com>