### PR TITLE
Provide the way to force compiling strnlen of system implementation

### DIFF
--- a/packcc.c
+++ b/packcc.c
@@ -47,7 +47,7 @@
 #include <stdbool.h>
 
 #ifndef _MSC_VER
-#if defined __GNUC__ && defined _WIN32 /* MinGW */
+#if ((defined USE_SYSTEM_STRNLEN) == 0) && defined __GNUC__ && defined _WIN32 /* MinGW */
 static size_t strnlen(const char *str, size_t maxlen) {
     size_t i;
     for (i = 0; str[i] && i < maxlen; i++);


### PR DESCRIPTION
When testing Universal-ctags on Appveyor CI environment,
I found a system provides strnlen even though defined __GNUC__ && defined _WIN32
is true. As the result, compiling packcc.c fails because of confliction of
the implementations of strnlen: system implementation and packcc private implementation.

This change introduces USE_SYSTEM_STRNLEN macro. If it is defined, the
private implementation is nerver used.

You can utilize the macro like:

    $ gcc -DUSE_SYSTEM_STRNLEN packcc.c

Signed-off-by: Masatake YAMATO <yamato@redhat.com>