### PR TITLE
Provide the way to use strnlen of system implementation when compiling generated code

### DIFF
--- a/packcc.c
+++ b/packcc.c
@@ -1982,7 +1982,7 @@ static bool parse(context_t *ctx) {
             "#include <stdbool.h>\n"
             "\n"
             "#ifndef _MSC_VER\n"
-            "#if defined __GNUC__ && defined _WIN32 /* MinGW */\n"
+            "#if ((defined USE_SYSTEM_STRNLEN) == 0) && defined __GNUC__ && defined _WIN32 /* MinGW */\n"
             "static size_t strnlen(const char *str, size_t maxlen) {\n"
             "    size_t i;\n"
             "    for (i = 0; i < maxlen && str[i]; i++);\n"


### PR DESCRIPTION
When testing Universal-ctags on Appveyor CI environment,
I found a system provides strnlen even though defined __GNUC__ && defined _WIN32
is true. As the result, compiling source code generated by packcc.c is fails because
of confliction of the implementations of strnlen: the system implementation and the
implementation emitted by packcc.

This change introduces USE_SYSTEM_STRNLEN macro. If it is defined, the
implementation emitted packcc is nerver used.

You can utilize the macro like:

	$ packcc foo.peg > foo.c
	$ gcc -DUSE_SYSTEM_STRNLEN foo.c

Signed-off-by: Masatake YAMATO <yamato@redhat.com>