### PR TITLE
Pointer cast is more likely correct than passing back array by value.

### DIFF
--- a/packcc.c
+++ b/packcc.c
@@ -473,7 +473,7 @@ static const char *escape_character(char ch, char (*buf)[5]) {
             snprintf(*buf, 5, "\\x%02x", (unsigned char)ch);
     }
     (*buf)[4] = '\0';
-    return *buf;
+    return (char *)buf;
 }
 
 static void remove_heading_blank(char *str) {


### PR DESCRIPTION
Since the array is bigger than 32-bits and the code should be endian agnostic otherwise, I'd suggest passing a pointer would be better since that's what the function signature indicates you're trying to do anyway.  Also a cast is necessary to make the pointer type compatible.

Signed-off-by: Samuel D. Crow <samuraileumas@yahoo.com>